### PR TITLE
Add RuntimeErrors for missing username or token

### DIFF
--- a/factorio-mod-updater
+++ b/factorio-mod-updater
@@ -5,6 +5,8 @@ require 'json'
 
 class ModService
   def initialize(username, token, server = "mods.factorio.com")
+    raise "Missing factorio.com username!" if username.empty?
+    raise "Missing factorio.com token!" if token.empty?
     @username = username
     @token = token
     @server_base_uri = URI("https://#{server}")


### PR DESCRIPTION
This PR adds runtime errors so its clear you're missing your factorio.com username or token before you get a 403 error like in issue #1.